### PR TITLE
Menu exporter needs to quit after exporting its XML, or else Wordpres…

### DIFF
--- a/menu-exporter.php
+++ b/menu-exporter.php
@@ -278,4 +278,5 @@ function me_export_wp( $args = array() ) {
 </channel>
 </rss>
 <?php
+    die();
 }


### PR DESCRIPTION
…s will also output its own XML and you end up with a single file containing two XML files.